### PR TITLE
References the default stylesheet in template head

### DIFF
--- a/Hugs/layouts/_default/baseof.html
+++ b/Hugs/layouts/_default/baseof.html
@@ -5,6 +5,7 @@
 	<title>{{ block "title" . }}{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}{{ end }}</title>
 	<meta charset="UTF-8">
 	<meta id="description" name="description" content="{{ block "description" . }}{{ if .Description }}{{ .Description }}{{ else }}{{ .Site.Params.SiteDescription }}{{ end }}{{ end }}"/>
+	<link rel="stylesheet" href="/css/styles.css" />
 </head>
 
 <body>


### PR DESCRIPTION
This adds a reference to `/css/styles.css` in the template header. 